### PR TITLE
Use 4-partition topic with partition-key worker distribution and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ dotnet run --project src/Producer/Producer.csproj
 ```
 
 The consumer subscribes to `sample-topic` with group id `sample-group`, and the producer sends a single `HelloMessage`.
+
+## Consumer concurrency and ordering
+
+The consumer uses KafkaFlow worker parallelism and `PartitionKeyDistributionStrategy` so messages from the
+same Kafka partition are always routed to the same worker (preserving partition order), while different
+partitions are processed in parallel.

--- a/src/Consumer/Program.cs
+++ b/src/Consumer/Program.cs
@@ -1,4 +1,5 @@
 using KafkaFlow;
+using KafkaFlow.Configuration;
 using KafkaFlow.Serializer;
 using Microsoft.Extensions.DependencyInjection;
 using ServiceStackApp;
@@ -11,12 +12,13 @@ services.AddKafka(kafka => kafka
     .UseConsoleLog()
     .AddCluster(cluster => cluster
         .WithBrokers(new[] { "localhost:9092" })
-        .CreateTopicIfNotExists(topicName, 1, 1)
+        .CreateTopicIfNotExists(topicName, 4, 1)
         .AddConsumer(consumer => consumer
             .Topic(topicName)
             .WithGroupId("sample-group")
             .WithBufferSize(100)
-            .WithWorkersCount(10)
+            .WithWorkersCount(4)
+            .WithWorkDistributionStrategy<PartitionKeyDistributionStrategy>()
             .AddMiddlewares(middlewares => middlewares
                 .AddDeserializer<JsonCoreDeserializer>()
                 .AddTypedHandlers(handlers => handlers

--- a/src/Producer/Program.cs
+++ b/src/Producer/Program.cs
@@ -13,7 +13,7 @@ services.AddKafka(kafka => kafka
     .UseConsoleLog()
     .AddCluster(cluster => cluster
         .WithBrokers(new[] { "localhost:9092" })
-        .CreateTopicIfNotExists(topicName, 1, 1)
+        .CreateTopicIfNotExists(topicName, 4, 1)
         .AddProducer(
             producerName,
             producer => producer


### PR DESCRIPTION
### Motivation

- Increase consumer throughput by using multiple Kafka partitions while preserving per-partition ordering through worker routing.
- Document the concurrency and ordering behavior for the consumer in the `README.md`.

### Description

- Change topic creation from 1 partition to 4 partitions by updating `CreateTopicIfNotExists(topicName, 4, 1)` in both `src/Consumer/Program.cs` and `src/Producer/Program.cs`.
- Configure the consumer to use `WithWorkersCount(4)` instead of `10` to match partition count and add `WithWorkDistributionStrategy<PartitionKeyDistributionStrategy>()` to ensure messages from the same Kafka partition are routed to the same worker.
- Update `README.md` to add a `Consumer concurrency and ordering` section that explains the use of worker parallelism and `PartitionKeyDistributionStrategy` to preserve partition order.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc934b8da08324b1ea30169391faa1)