### PR TITLE
Add OrderCreatedMessage and orders-topic producer/consumer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository uses [KafkaFlow](https://farfetch.github.io/kafkaflow/) with a c
 
 - `src/Producer`: KafkaFlow **producer** console app
 - `src/Consumer`: KafkaFlow **consumer** console app
-- `src/Contracts`: shared message contract (`HelloMessage`)
+- `src/Contracts`: shared message contracts (`HelloMessage`, `OrderCreatedMessage`)
 - `tests/Consumer.Tests`: NUnit tests for consumer formatting logic
 
 ## Prerequisites
@@ -19,17 +19,20 @@ This repository uses [KafkaFlow](https://farfetch.github.io/kafkaflow/) with a c
 ```bash
 dotnet restore
 
-# terminal 1: run consumer
+# terminal 1: run consumers
 dotnet run --project src/Consumer/Consumer.csproj
 
-# terminal 2: send one message
+# terminal 2: send messages
 dotnet run --project src/Producer/Producer.csproj
 ```
 
-The consumer subscribes to `sample-topic` with group id `sample-group`, and the producer sends a single `HelloMessage`.
+The app demonstrates support for topics with different message types:
+
+- `hello-topic` consumes `HelloMessage` with `HelloMessageHandler`
+- `orders-topic` consumes `OrderCreatedMessage` with `OrderCreatedMessageHandler`
 
 ## Consumer concurrency and ordering
 
-The consumer uses KafkaFlow worker parallelism and `PartitionKeyDistributionStrategy` so messages from the
+Each consumer uses KafkaFlow worker parallelism and `PartitionKeyDistributionStrategy` so messages from the
 same Kafka partition are always routed to the same worker (preserving partition order), while different
 partitions are processed in parallel.

--- a/src/Consumer/OrderCreatedMessageHandler.cs
+++ b/src/Consumer/OrderCreatedMessageHandler.cs
@@ -1,0 +1,18 @@
+using KafkaFlow;
+using ServiceStackApp.ServiceModel;
+
+namespace ServiceStackApp;
+
+public class OrderCreatedMessageHandler : IMessageHandler<OrderCreatedMessage>
+{
+    public Task Handle(IMessageContext context, OrderCreatedMessage message)
+    {
+        var output = MessageFormatter.Format(
+            context.ConsumerContext.Partition,
+            context.ConsumerContext.Offset,
+            $"Order Created | Id: {message.OrderId} | Total: {message.Total}");
+
+        Console.WriteLine(output);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Consumer/Program.cs
+++ b/src/Consumer/Program.cs
@@ -4,7 +4,8 @@ using KafkaFlow.Serializer;
 using Microsoft.Extensions.DependencyInjection;
 using ServiceStackApp;
 
-const string topicName = "sample-topic";
+const string helloTopicName = "hello-topic";
+const string ordersTopicName = "orders-topic";
 
 var services = new ServiceCollection();
 
@@ -12,24 +13,35 @@ services.AddKafka(kafka => kafka
     .UseConsoleLog()
     .AddCluster(cluster => cluster
         .WithBrokers(new[] { "localhost:9092" })
-        .CreateTopicIfNotExists(topicName, 4, 1)
+        .CreateTopicIfNotExists(helloTopicName, 4, 1)
+        .CreateTopicIfNotExists(ordersTopicName, 4, 1)
         .AddConsumer(consumer => consumer
-            .Topic(topicName)
-            .WithGroupId("sample-group")
+            .Topic(helloTopicName)
+            .WithGroupId("hello-group")
             .WithBufferSize(100)
             .WithWorkersCount(4)
             .WithWorkDistributionStrategy<PartitionKeyDistributionStrategy>()
             .AddMiddlewares(middlewares => middlewares
                 .AddDeserializer<JsonCoreDeserializer>()
                 .AddTypedHandlers(handlers => handlers
-                    .AddHandler<HelloMessageHandler>())))));
+                    .AddHandler<HelloMessageHandler>())))
+        .AddConsumer(consumer => consumer
+            .Topic(ordersTopicName)
+            .WithGroupId("orders-group")
+            .WithBufferSize(100)
+            .WithWorkersCount(4)
+            .WithWorkDistributionStrategy<PartitionKeyDistributionStrategy>()
+            .AddMiddlewares(middlewares => middlewares
+                .AddDeserializer<JsonCoreDeserializer>()
+                .AddTypedHandlers(handlers => handlers
+                    .AddHandler<OrderCreatedMessageHandler>())))));
 
 var serviceProvider = services.BuildServiceProvider();
 var bus = serviceProvider.CreateKafkaBus();
 
 await bus.StartAsync();
 
-Console.WriteLine("KafkaFlow consumer is running. Press ENTER to stop.");
+Console.WriteLine("KafkaFlow consumers are running. Press ENTER to stop.");
 Console.ReadLine();
 
 await bus.StopAsync();

--- a/src/Contracts/OrderCreatedMessage.cs
+++ b/src/Contracts/OrderCreatedMessage.cs
@@ -1,0 +1,7 @@
+namespace ServiceStackApp.ServiceModel;
+
+public class OrderCreatedMessage
+{
+    public string OrderId { get; set; } = string.Empty;
+    public decimal Total { get; set; }
+}

--- a/src/Producer/Program.cs
+++ b/src/Producer/Program.cs
@@ -4,8 +4,9 @@ using KafkaFlow.Serializer;
 using Microsoft.Extensions.DependencyInjection;
 using ServiceStackApp.ServiceModel;
 
-const string topicName = "sample-topic";
-const string producerName = "say-hello";
+const string helloTopicName = "hello-topic";
+const string ordersTopicName = "orders-topic";
+const string producerName = "sample-producer";
 
 var services = new ServiceCollection();
 
@@ -13,11 +14,12 @@ services.AddKafka(kafka => kafka
     .UseConsoleLog()
     .AddCluster(cluster => cluster
         .WithBrokers(new[] { "localhost:9092" })
-        .CreateTopicIfNotExists(topicName, 4, 1)
+        .CreateTopicIfNotExists(helloTopicName, 4, 1)
+        .CreateTopicIfNotExists(ordersTopicName, 4, 1)
         .AddProducer(
             producerName,
             producer => producer
-                .DefaultTopic(topicName)
+                .DefaultTopic(helloTopicName)
                 .AddMiddlewares(m => m.AddSerializer<JsonCoreSerializer>()))));
 
 var serviceProvider = services.BuildServiceProvider();
@@ -27,8 +29,17 @@ var producer = serviceProvider
     .GetProducer(producerName);
 
 await producer.ProduceAsync(
-    topicName,
+    helloTopicName,
     Guid.NewGuid().ToString(),
     new HelloMessage { Text = "Hello from KafkaFlow producer" });
 
-Console.WriteLine("Message sent.");
+await producer.ProduceAsync(
+    ordersTopicName,
+    Guid.NewGuid().ToString(),
+    new OrderCreatedMessage
+    {
+        OrderId = Guid.NewGuid().ToString("N"),
+        Total = 149.99m
+    });
+
+Console.WriteLine("Messages sent to hello-topic and orders-topic.");


### PR DESCRIPTION
### Motivation

- Demonstrate multi-topic support and different message types in the sample app by adding an `OrderCreatedMessage` example.
- Provide a consumer handler and producer flow for an `orders-topic` in addition to the existing `hello-topic` example.
- Update documentation to reflect the new topics and message types.

### Description

- Add new contract `OrderCreatedMessage` in `src/Contracts/OrderCreatedMessage.cs` with `OrderId` and `Total` properties.
- Add `OrderCreatedMessageHandler` in `src/Consumer/OrderCreatedMessageHandler.cs` that formats and writes order messages to the console.
- Update consumer configuration in `src/Consumer/Program.cs` to create `hello-topic` and `orders-topic`, add separate consumers with group ids `hello-group` and `orders-group`, and register the corresponding typed handlers.
- Update producer in `src/Producer/Program.cs` to create both topics, set the default producer topic to `hello-topic`, and send one `HelloMessage` and one `OrderCreatedMessage` to their respective topics.
- Update `README.md` to document the new `hello-topic`/`orders-topic` mapping and adjust run instructions and descriptions.

### Testing

- Ran `dotnet build` across the solution to verify compilation, and the build completed successfully.
- Executed the existing test suite with `dotnet test` for `tests/Consumer.Tests`, and the tests passed.
- Manual smoke tested producing and consuming messages by running the producer and consumer projects locally, confirming both `hello-topic` and `orders-topic` messages are produced and handled as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcbb0e29208324a142d3cceb50fd8f)