### PR TITLE
Add producer/consumer logging middleware with DI-backed instance tracking and README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ The app demonstrates support for topics with different message types:
 - `hello-topic` consumes `HelloMessage` with `HelloMessageHandler`
 - `orders-topic` consumes `OrderCreatedMessage` with `OrderCreatedMessageHandler`
 
+## Middleware pipeline, DI, and lifetime control
+
+Both producer and consumers define middleware pipelines with explicit order:
+
+- Producer pipeline: `ProducerLoggingMiddleware` -> `JsonCoreSerializer`
+- Consumer pipeline: `ConsumerLoggingMiddleware` -> `JsonCoreDeserializer` -> typed handlers
+
+Custom middleware classes are created through `Microsoft.Extensions.DependencyInjection` and use constructor
+injection (`MiddlewareInstanceTracker`) to demonstrate DI-driven middleware activation.
+
+The middleware is registered using the lifetime overload:
+
+- `.Add<ProducerLoggingMiddleware>(MiddlewareLifetime.Singleton)`
+- `.Add<ConsumerLoggingMiddleware>(MiddlewareLifetime.Singleton)`
+
 ## Consumer concurrency and ordering
 
 Each consumer uses KafkaFlow worker parallelism and `PartitionKeyDistributionStrategy` so messages from the

--- a/src/Consumer/ConsumerLoggingMiddleware.cs
+++ b/src/Consumer/ConsumerLoggingMiddleware.cs
@@ -1,0 +1,16 @@
+using KafkaFlow;
+
+namespace ServiceStackApp;
+
+public class ConsumerLoggingMiddleware(MiddlewareInstanceTracker tracker) : IMessageMiddleware
+{
+    private readonly string _instanceId = tracker.GetOrCreateId<ConsumerLoggingMiddleware>();
+
+    public async Task Invoke(IMessageContext context, MiddlewareDelegate next)
+    {
+        Console.WriteLine(
+            $"[ConsumerMiddleware:{_instanceId}] Topic={context.ConsumerContext.Topic} Partition={context.ConsumerContext.Partition} Offset={context.ConsumerContext.Offset}");
+
+        await next(context);
+    }
+}

--- a/src/Consumer/MiddlewareInstanceTracker.cs
+++ b/src/Consumer/MiddlewareInstanceTracker.cs
@@ -1,0 +1,22 @@
+namespace ServiceStackApp;
+
+public class MiddlewareInstanceTracker
+{
+    private readonly Dictionary<Type, string> _instances = new();
+    private readonly Lock _gate = new();
+
+    public string GetOrCreateId<TMiddleware>()
+    {
+        lock (_gate)
+        {
+            if (_instances.TryGetValue(typeof(TMiddleware), out var existing))
+            {
+                return existing;
+            }
+
+            var created = Guid.NewGuid().ToString("N")[..8];
+            _instances[typeof(TMiddleware)] = created;
+            return created;
+        }
+    }
+}

--- a/src/Consumer/Program.cs
+++ b/src/Consumer/Program.cs
@@ -8,6 +8,7 @@ const string helloTopicName = "hello-topic";
 const string ordersTopicName = "orders-topic";
 
 var services = new ServiceCollection();
+services.AddSingleton<MiddlewareInstanceTracker>();
 
 services.AddKafka(kafka => kafka
     .UseConsoleLog()
@@ -22,6 +23,7 @@ services.AddKafka(kafka => kafka
             .WithWorkersCount(4)
             .WithWorkDistributionStrategy<PartitionKeyDistributionStrategy>()
             .AddMiddlewares(middlewares => middlewares
+                .Add<ConsumerLoggingMiddleware>(MiddlewareLifetime.Singleton)
                 .AddDeserializer<JsonCoreDeserializer>()
                 .AddTypedHandlers(handlers => handlers
                     .AddHandler<HelloMessageHandler>())))
@@ -32,6 +34,7 @@ services.AddKafka(kafka => kafka
             .WithWorkersCount(4)
             .WithWorkDistributionStrategy<PartitionKeyDistributionStrategy>()
             .AddMiddlewares(middlewares => middlewares
+                .Add<ConsumerLoggingMiddleware>(MiddlewareLifetime.Singleton)
                 .AddDeserializer<JsonCoreDeserializer>()
                 .AddTypedHandlers(handlers => handlers
                     .AddHandler<OrderCreatedMessageHandler>())))));

--- a/src/Producer/MiddlewareInstanceTracker.cs
+++ b/src/Producer/MiddlewareInstanceTracker.cs
@@ -1,0 +1,22 @@
+namespace ServiceStackApp.ServiceModel;
+
+public class MiddlewareInstanceTracker
+{
+    private readonly Dictionary<Type, string> _instances = new();
+    private readonly Lock _gate = new();
+
+    public string GetOrCreateId<TMiddleware>()
+    {
+        lock (_gate)
+        {
+            if (_instances.TryGetValue(typeof(TMiddleware), out var existing))
+            {
+                return existing;
+            }
+
+            var created = Guid.NewGuid().ToString("N")[..8];
+            _instances[typeof(TMiddleware)] = created;
+            return created;
+        }
+    }
+}

--- a/src/Producer/ProducerLoggingMiddleware.cs
+++ b/src/Producer/ProducerLoggingMiddleware.cs
@@ -1,0 +1,16 @@
+using KafkaFlow;
+
+namespace ServiceStackApp.ServiceModel;
+
+public class ProducerLoggingMiddleware(MiddlewareInstanceTracker tracker) : IMessageMiddleware
+{
+    private readonly string _instanceId = tracker.GetOrCreateId<ProducerLoggingMiddleware>();
+
+    public async Task Invoke(IMessageContext context, MiddlewareDelegate next)
+    {
+        Console.WriteLine(
+            $"[ProducerMiddleware:{_instanceId}] Topic={context.ProducerContext.Topic} Key={context.Message.Key}");
+
+        await next(context);
+    }
+}

--- a/src/Producer/Program.cs
+++ b/src/Producer/Program.cs
@@ -9,6 +9,7 @@ const string ordersTopicName = "orders-topic";
 const string producerName = "sample-producer";
 
 var services = new ServiceCollection();
+services.AddSingleton<MiddlewareInstanceTracker>();
 
 services.AddKafka(kafka => kafka
     .UseConsoleLog()
@@ -20,7 +21,9 @@ services.AddKafka(kafka => kafka
             producerName,
             producer => producer
                 .DefaultTopic(helloTopicName)
-                .AddMiddlewares(m => m.AddSerializer<JsonCoreSerializer>()))));
+                .AddMiddlewares(m => m
+                    .Add<ProducerLoggingMiddleware>(MiddlewareLifetime.Singleton)
+                    .AddSerializer<JsonCoreSerializer>()))));
 
 var serviceProvider = services.BuildServiceProvider();
 


### PR DESCRIPTION
### Motivation

- Introduce simple logging middleware for both producer and consumer pipelines to surface runtime topic/partition/key context and illustrate middleware ordering.  
- Demonstrate middleware activation via dependency injection and control middleware lifetimes explicitly.  
- Document the pipeline, DI, and lifetime choices in `README.md`.

### Description

- Added `ProducerLoggingMiddleware` and `ConsumerLoggingMiddleware` that log message context and use a shared `MiddlewareInstanceTracker` to emit a short instance id.  
- Introduced `MiddlewareInstanceTracker` in both `src/Producer` and `src/Consumer` namespaces to generate and reuse middleware instance ids.  
- Registered the tracker as a singleton with DI in `Producer/Program.cs` and `Consumer/Program.cs` and added middleware to the pipelines using `.Add<...>(MiddlewareLifetime.Singleton)` before the serializer/deserializer.  
- Updated `README.md` with a new “Middleware pipeline, DI, and lifetime control” section describing pipeline order and registration patterns.

### Testing

- No automated tests were added or executed as part of this change.  
- Existing test projects (e.g. `tests/Consumer.Tests`) were not modified by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcbe2701b483248dbe6fc74f73381c)