### PR TITLE
Add Gzip compressor/decompressor middleware and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ The app demonstrates support for topics with different message types:
 
 Both producer and consumers define middleware pipelines with explicit order:
 
-- Producer pipeline: `ProducerLoggingMiddleware` -> `JsonCoreSerializer`
-- Consumer pipeline: `ConsumerLoggingMiddleware` -> `JsonCoreDeserializer` -> typed handlers
+- Producer pipeline: `ProducerLoggingMiddleware` -> `GzipMessageCompressor` -> `JsonCoreSerializer`
+- Consumer pipeline: `ConsumerLoggingMiddleware` -> `GzipMessageDecompressor` -> `JsonCoreDeserializer` -> typed handlers
 
 Custom middleware classes are created through `Microsoft.Extensions.DependencyInjection` and use constructor
 injection (`MiddlewareInstanceTracker`) to demonstrate DI-driven middleware activation.

--- a/src/Consumer/Consumer.csproj
+++ b/src/Consumer/Consumer.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="KafkaFlow" Version="3.*" />
+    <PackageReference Include="KafkaFlow.Compressor.Gzip" Version="3.*" />
     <PackageReference Include="KafkaFlow.LogHandler.Console" Version="3.*" />
     <PackageReference Include="KafkaFlow.Microsoft.DependencyInjection" Version="3.*" />
     <PackageReference Include="KafkaFlow.Serializer.JsonCore" Version="3.*" />

--- a/src/Consumer/Program.cs
+++ b/src/Consumer/Program.cs
@@ -1,4 +1,5 @@
 using KafkaFlow;
+using KafkaFlow.Compressor.Gzip;
 using KafkaFlow.Configuration;
 using KafkaFlow.Serializer;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,6 +25,7 @@ services.AddKafka(kafka => kafka
             .WithWorkDistributionStrategy<PartitionKeyDistributionStrategy>()
             .AddMiddlewares(middlewares => middlewares
                 .Add<ConsumerLoggingMiddleware>(MiddlewareLifetime.Singleton)
+                .AddDecompressor<GzipMessageDecompressor>()
                 .AddDeserializer<JsonCoreDeserializer>()
                 .AddTypedHandlers(handlers => handlers
                     .AddHandler<HelloMessageHandler>())))
@@ -35,6 +37,7 @@ services.AddKafka(kafka => kafka
             .WithWorkDistributionStrategy<PartitionKeyDistributionStrategy>()
             .AddMiddlewares(middlewares => middlewares
                 .Add<ConsumerLoggingMiddleware>(MiddlewareLifetime.Singleton)
+                .AddDecompressor<GzipMessageDecompressor>()
                 .AddDeserializer<JsonCoreDeserializer>()
                 .AddTypedHandlers(handlers => handlers
                     .AddHandler<OrderCreatedMessageHandler>())))));

--- a/src/Producer/Producer.csproj
+++ b/src/Producer/Producer.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="KafkaFlow" Version="3.*" />
+    <PackageReference Include="KafkaFlow.Compressor.Gzip" Version="3.*" />
     <PackageReference Include="KafkaFlow.LogHandler.Console" Version="3.*" />
     <PackageReference Include="KafkaFlow.Microsoft.DependencyInjection" Version="3.*" />
     <PackageReference Include="KafkaFlow.Serializer.JsonCore" Version="3.*" />

--- a/src/Producer/Program.cs
+++ b/src/Producer/Program.cs
@@ -1,4 +1,5 @@
 using KafkaFlow;
+using KafkaFlow.Compressor.Gzip;
 using KafkaFlow.Producers;
 using KafkaFlow.Serializer;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,6 +24,7 @@ services.AddKafka(kafka => kafka
                 .DefaultTopic(helloTopicName)
                 .AddMiddlewares(m => m
                     .Add<ProducerLoggingMiddleware>(MiddlewareLifetime.Singleton)
+                    .AddCompressor<GzipMessageCompressor>()
                     .AddSerializer<JsonCoreSerializer>()))));
 
 var serviceProvider = services.BuildServiceProvider();


### PR DESCRIPTION
### Motivation
- Enable transparent message compression to reduce payload sizes when producing and consuming messages.
- Document the updated middleware pipelines to reflect compression support.

### Description
- Added `KafkaFlow.Compressor.Gzip` package references to both `Producer` and `Consumer` projects.
- Wire up `GzipMessageCompressor` in the producer middleware pipeline via `.AddCompressor<GzipMessageCompressor>()`.
- Wire up `GzipMessageDecompressor` in the consumer middleware pipeline via `.AddDecompressor<GzipMessageDecompressor>()`.
- Updated `README.md` to show the new producer and consumer middleware pipelines including gzip compress/decompress steps.

### Testing
- Restored and built the projects with `dotnet restore` and `dotnet build`, and the build completed successfully.
- No automated unit tests were present or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69def064b7a0832488bf12361d8072c2)