### PR TITLE
Add KafkaFlow.Retry RetrySimple middleware to consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The app demonstrates support for topics with different message types:
 Both producer and consumers define middleware pipelines with explicit order:
 
 - Producer pipeline: `ProducerLoggingMiddleware` -> `GzipMessageCompressor` -> `JsonCoreSerializer`
-- Consumer pipeline: `ConsumerLoggingMiddleware` -> `GzipMessageDecompressor` -> `JsonCoreDeserializer` -> typed handlers
+- Consumer pipeline: `RetrySimple` -> `ConsumerLoggingMiddleware` -> `GzipMessageDecompressor` -> `JsonCoreDeserializer` -> typed handlers
 
 Custom middleware classes are created through `Microsoft.Extensions.DependencyInjection` and use constructor
 injection (`MiddlewareInstanceTracker`) to demonstrate DI-driven middleware activation.
@@ -45,6 +45,8 @@ The middleware is registered using the lifetime overload:
 
 - `.Add<ProducerLoggingMiddleware>(MiddlewareLifetime.Singleton)`
 - `.Add<ConsumerLoggingMiddleware>(MiddlewareLifetime.Singleton)`
+
+Consumer exception handling uses `KafkaFlow.Retry` middleware with `RetrySimple(...).HandleAnyException()`.
 
 ## Consumer concurrency and ordering
 

--- a/src/Consumer/Consumer.csproj
+++ b/src/Consumer/Consumer.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="KafkaFlow.Compressor.Gzip" Version="3.*" />
     <PackageReference Include="KafkaFlow.LogHandler.Console" Version="3.*" />
     <PackageReference Include="KafkaFlow.Microsoft.DependencyInjection" Version="3.*" />
+    <PackageReference Include="KafkaFlow.Retry" Version="1.*" />
     <PackageReference Include="KafkaFlow.Serializer.JsonCore" Version="3.*" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.*" />
   </ItemGroup>

--- a/src/Consumer/Program.cs
+++ b/src/Consumer/Program.cs
@@ -1,6 +1,7 @@
 using KafkaFlow;
 using KafkaFlow.Compressor.Gzip;
 using KafkaFlow.Configuration;
+using KafkaFlow.Retry;
 using KafkaFlow.Serializer;
 using Microsoft.Extensions.DependencyInjection;
 using ServiceStackApp;
@@ -24,6 +25,10 @@ services.AddKafka(kafka => kafka
             .WithWorkersCount(4)
             .WithWorkDistributionStrategy<PartitionKeyDistributionStrategy>()
             .AddMiddlewares(middlewares => middlewares
+                .RetrySimple(config => config
+                    .HandleAnyException()
+                    .TryTimes(3)
+                    .WithTimeBetweenTriesPlan(retryCount => TimeSpan.FromMilliseconds(Math.Pow(2, retryCount) * 100)))
                 .Add<ConsumerLoggingMiddleware>(MiddlewareLifetime.Singleton)
                 .AddDecompressor<GzipMessageDecompressor>()
                 .AddDeserializer<JsonCoreDeserializer>()
@@ -36,6 +41,10 @@ services.AddKafka(kafka => kafka
             .WithWorkersCount(4)
             .WithWorkDistributionStrategy<PartitionKeyDistributionStrategy>()
             .AddMiddlewares(middlewares => middlewares
+                .RetrySimple(config => config
+                    .HandleAnyException()
+                    .TryTimes(3)
+                    .WithTimeBetweenTriesPlan(retryCount => TimeSpan.FromMilliseconds(Math.Pow(2, retryCount) * 100)))
                 .Add<ConsumerLoggingMiddleware>(MiddlewareLifetime.Singleton)
                 .AddDecompressor<GzipMessageDecompressor>()
                 .AddDeserializer<JsonCoreDeserializer>()


### PR DESCRIPTION
### Motivation

- Introduce automatic retry handling for consumer message processing to handle transient errors and reduce manual retry logic.
- Document the new consumer middleware ordering and exception handling behavior in the README.

### Description

- Add a dependency on `KafkaFlow.Retry` and import it with `using KafkaFlow.Retry;` in the consumer project and code.
- Register `RetrySimple(...)` at the start of each consumer middleware pipeline and configure it with `HandleAnyException()`, `TryTimes(3)`, and an exponential backoff via `WithTimeBetweenTriesPlan(retryCount => TimeSpan.FromMilliseconds(Math.Pow(2, retryCount) * 100))`.
- Update README to reflect the new middleware order and note that consumer exception handling uses `KafkaFlow.Retry` with `RetrySimple(...).HandleAnyException()`.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df0d656dd48324b80ad15ffe8f5944)