### PR TITLE
Add DbEncryption library (Data Protection-backed) with per-field PII encryption and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ This repository uses [KafkaFlow](https://farfetch.github.io/kafkaflow/) with a c
 - `src/Producer`: KafkaFlow **producer** console app
 - `src/Consumer`: KafkaFlow **consumer** console app
 - `src/Contracts`: shared message contracts (`HelloMessage`, `OrderCreatedMessage`)
+- `src/DbEncryption`: shared Microsoft Data Protection helpers for protecting patient identifiable information before persistence
 - `tests/Consumer.Tests`: NUnit tests for consumer formatting logic
+- `tests/ServiceStackApp.Tests`: NUnit tests for patient identifiable information encryption
 
 ## Prerequisites
 
@@ -57,3 +59,7 @@ Consumer exception handling uses `KafkaFlow.Retry` middleware with `RetrySimple(
 Each consumer uses KafkaFlow worker parallelism and `PartitionKeyDistributionStrategy` so messages from the
 same Kafka partition are always routed to the same worker (preserving partition order), while different
 partitions are processed in parallel.
+
+## DB encryption helpers
+
+The `DbEncryption` class library provides a patient identifiable information encryption service backed by the Microsoft Data Protection API. Store each protected payload and purpose together so protected patient fields can be unprotected after retrieval. Configure Data Protection key persistence for the deployment environment so application instances can share and rotate keys safely.

--- a/ServiceStackApp.sln
+++ b/ServiceStackApp.sln
@@ -10,6 +10,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Consumer.Tests", "tests\Con
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Producer", "src\Producer\Producer.csproj", "{62ADD6CF-EB0B-4D5D-99BB-04FB02748D82}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbEncryption", "src\DbEncryption\DbEncryption.csproj", "{9C3353A3-8D1E-4A18-A57B-2F05D4EC3B1F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceStackApp.Tests", "tests\ServiceStackApp.Tests\ServiceStackApp.Tests.csproj", "{1B51B29D-0EAD-486F-82F1-21631A7EC4D6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +36,14 @@ Global
 		{62ADD6CF-EB0B-4D5D-99BB-04FB02748D82}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{62ADD6CF-EB0B-4D5D-99BB-04FB02748D82}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{62ADD6CF-EB0B-4D5D-99BB-04FB02748D82}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C3353A3-8D1E-4A18-A57B-2F05D4EC3B1F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C3353A3-8D1E-4A18-A57B-2F05D4EC3B1F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C3353A3-8D1E-4A18-A57B-2F05D4EC3B1F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C3353A3-8D1E-4A18-A57B-2F05D4EC3B1F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1B51B29D-0EAD-486F-82F1-21631A7EC4D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B51B29D-0EAD-486F-82F1-21631A7EC4D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B51B29D-0EAD-486F-82F1-21631A7EC4D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B51B29D-0EAD-486F-82F1-21631A7EC4D6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/DbEncryption/DataProtectionDbEncryptionService.cs
+++ b/src/DbEncryption/DataProtectionDbEncryptionService.cs
@@ -1,0 +1,67 @@
+using Microsoft.AspNetCore.DataProtection;
+
+namespace DbEncryption;
+
+/// <summary>
+/// Database encryption service backed by the Microsoft Data Protection API.
+/// </summary>
+public sealed class DataProtectionDbEncryptionService : IDbEncryptionService
+{
+    public const string DefaultPurpose = "ServiceStackApp.DbEncryption.DatabaseValue";
+
+    private readonly IDataProtectionProvider dataProtectionProvider;
+    private readonly string defaultPurpose;
+
+    public DataProtectionDbEncryptionService(
+        IDataProtectionProvider dataProtectionProvider,
+        string defaultPurpose = DefaultPurpose)
+    {
+        ArgumentNullException.ThrowIfNull(dataProtectionProvider);
+
+        if (string.IsNullOrWhiteSpace(defaultPurpose))
+        {
+            throw new ArgumentException("A non-empty Data Protection purpose is required.", nameof(defaultPurpose));
+        }
+
+        this.dataProtectionProvider = dataProtectionProvider;
+        this.defaultPurpose = defaultPurpose;
+    }
+
+    public EncryptedValue Encrypt(ReadOnlySpan<byte> plainText, string? purpose = null)
+    {
+        var resolvedPurpose = ResolvePurpose(purpose);
+        var protector = dataProtectionProvider.CreateProtector(resolvedPurpose);
+        var protectedData = protector.Protect(plainText.ToArray());
+
+        return new EncryptedValue(protectedData, resolvedPurpose);
+    }
+
+    public byte[] Decrypt(EncryptedValue encryptedValue)
+    {
+        ArgumentNullException.ThrowIfNull(encryptedValue);
+
+        if (string.IsNullOrWhiteSpace(encryptedValue.Purpose))
+        {
+            throw new ArgumentException("Encrypted values must include the Data Protection purpose used to protect them.", nameof(encryptedValue));
+        }
+
+        var protector = dataProtectionProvider.CreateProtector(encryptedValue.Purpose);
+
+        return protector.Unprotect(encryptedValue.ProtectedData);
+    }
+
+    private string ResolvePurpose(string? purpose)
+    {
+        if (purpose is null)
+        {
+            return defaultPurpose;
+        }
+
+        if (string.IsNullOrWhiteSpace(purpose))
+        {
+            throw new ArgumentException("A non-empty Data Protection purpose is required.", nameof(purpose));
+        }
+
+        return purpose;
+    }
+}

--- a/src/DbEncryption/DbEncryption.csproj
+++ b/src/DbEncryption/DbEncryption.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.*" />
+  </ItemGroup>
+</Project>

--- a/src/DbEncryption/EncryptedPatientIdentifiableInformation.cs
+++ b/src/DbEncryption/EncryptedPatientIdentifiableInformation.cs
@@ -1,0 +1,14 @@
+namespace DbEncryption;
+
+/// <summary>
+/// Protected patient identifiable information fields that are safe to persist in a database.
+/// </summary>
+public sealed record EncryptedPatientIdentifiableInformation(
+    string PatientId,
+    EncryptedValue FirstName,
+    EncryptedValue LastName,
+    EncryptedValue DateOfBirth,
+    EncryptedValue? MedicalRecordNumber = null,
+    EncryptedValue? EmailAddress = null,
+    EncryptedValue? PhoneNumber = null,
+    EncryptedValue? StreetAddress = null);

--- a/src/DbEncryption/EncryptedValue.cs
+++ b/src/DbEncryption/EncryptedValue.cs
@@ -1,0 +1,13 @@
+namespace DbEncryption;
+
+/// <summary>
+/// Represents a database value protected by the Microsoft Data Protection API.
+/// </summary>
+/// <param name="ProtectedData">The protected payload to persist in the database.</param>
+/// <param name="Purpose">The Data Protection purpose used to derive the protector.</param>
+public sealed record EncryptedValue(
+    byte[] ProtectedData,
+    string Purpose)
+{
+    public string ProtectedDataBase64 => Convert.ToBase64String(ProtectedData);
+}

--- a/src/DbEncryption/IDbEncryptionService.cs
+++ b/src/DbEncryption/IDbEncryptionService.cs
@@ -1,0 +1,11 @@
+namespace DbEncryption;
+
+/// <summary>
+/// Protects and unprotects database values before they are persisted or after they are read.
+/// </summary>
+public interface IDbEncryptionService
+{
+    EncryptedValue Encrypt(ReadOnlySpan<byte> plainText, string? purpose = null);
+
+    byte[] Decrypt(EncryptedValue encryptedValue);
+}

--- a/src/DbEncryption/IPatientIdentifiableInformationEncryptionService.cs
+++ b/src/DbEncryption/IPatientIdentifiableInformationEncryptionService.cs
@@ -1,0 +1,11 @@
+namespace DbEncryption;
+
+/// <summary>
+/// Encrypts and decrypts patient identifiable information fields before database persistence and after retrieval.
+/// </summary>
+public interface IPatientIdentifiableInformationEncryptionService
+{
+    EncryptedPatientIdentifiableInformation Encrypt(PatientIdentifiableInformation patientInformation);
+
+    PatientIdentifiableInformation Decrypt(EncryptedPatientIdentifiableInformation encryptedPatientInformation);
+}

--- a/src/DbEncryption/PatientIdentifiableInformation.cs
+++ b/src/DbEncryption/PatientIdentifiableInformation.cs
@@ -1,0 +1,14 @@
+namespace DbEncryption;
+
+/// <summary>
+/// Patient identifiable information that should be protected before database persistence.
+/// </summary>
+public sealed record PatientIdentifiableInformation(
+    string PatientId,
+    string FirstName,
+    string LastName,
+    DateOnly DateOfBirth,
+    string? MedicalRecordNumber = null,
+    string? EmailAddress = null,
+    string? PhoneNumber = null,
+    string? StreetAddress = null);

--- a/src/DbEncryption/PatientIdentifiableInformationEncryptionService.cs
+++ b/src/DbEncryption/PatientIdentifiableInformationEncryptionService.cs
@@ -1,0 +1,126 @@
+using System.Text;
+
+namespace DbEncryption;
+
+/// <summary>
+/// Protects patient identifiable information fields with distinct Data Protection purposes per field.
+/// </summary>
+public sealed class PatientIdentifiableInformationEncryptionService : IPatientIdentifiableInformationEncryptionService
+{
+    private const string DateOnlyFormat = "yyyy-MM-dd";
+
+    private readonly IDbEncryptionService dbEncryptionService;
+
+    public PatientIdentifiableInformationEncryptionService(IDbEncryptionService dbEncryptionService)
+    {
+        ArgumentNullException.ThrowIfNull(dbEncryptionService);
+
+        this.dbEncryptionService = dbEncryptionService;
+    }
+
+    public EncryptedPatientIdentifiableInformation Encrypt(PatientIdentifiableInformation patientInformation)
+    {
+        ArgumentNullException.ThrowIfNull(patientInformation);
+
+        if (string.IsNullOrWhiteSpace(patientInformation.PatientId))
+        {
+            throw new ArgumentException("Patient identifiable information must include a patient identifier.", nameof(patientInformation));
+        }
+
+        return new EncryptedPatientIdentifiableInformation(
+            patientInformation.PatientId,
+            ProtectRequired(patientInformation.FirstName, patientInformation.PatientId, PatientInformationField.FirstName),
+            ProtectRequired(patientInformation.LastName, patientInformation.PatientId, PatientInformationField.LastName),
+            ProtectRequired(patientInformation.DateOfBirth.ToString(DateOnlyFormat), patientInformation.PatientId, PatientInformationField.DateOfBirth),
+            ProtectOptional(patientInformation.MedicalRecordNumber, patientInformation.PatientId, PatientInformationField.MedicalRecordNumber),
+            ProtectOptional(patientInformation.EmailAddress, patientInformation.PatientId, PatientInformationField.EmailAddress),
+            ProtectOptional(patientInformation.PhoneNumber, patientInformation.PatientId, PatientInformationField.PhoneNumber),
+            ProtectOptional(patientInformation.StreetAddress, patientInformation.PatientId, PatientInformationField.StreetAddress));
+    }
+
+    public PatientIdentifiableInformation Decrypt(EncryptedPatientIdentifiableInformation encryptedPatientInformation)
+    {
+        ArgumentNullException.ThrowIfNull(encryptedPatientInformation);
+
+        if (string.IsNullOrWhiteSpace(encryptedPatientInformation.PatientId))
+        {
+            throw new ArgumentException("Encrypted patient identifiable information must include a patient identifier.", nameof(encryptedPatientInformation));
+        }
+
+        return new PatientIdentifiableInformation(
+            encryptedPatientInformation.PatientId,
+            UnprotectRequired(encryptedPatientInformation.FirstName, encryptedPatientInformation.PatientId, PatientInformationField.FirstName),
+            UnprotectRequired(encryptedPatientInformation.LastName, encryptedPatientInformation.PatientId, PatientInformationField.LastName),
+            DateOnly.ParseExact(UnprotectRequired(encryptedPatientInformation.DateOfBirth, encryptedPatientInformation.PatientId, PatientInformationField.DateOfBirth), DateOnlyFormat),
+            UnprotectOptional(encryptedPatientInformation.MedicalRecordNumber, encryptedPatientInformation.PatientId, PatientInformationField.MedicalRecordNumber),
+            UnprotectOptional(encryptedPatientInformation.EmailAddress, encryptedPatientInformation.PatientId, PatientInformationField.EmailAddress),
+            UnprotectOptional(encryptedPatientInformation.PhoneNumber, encryptedPatientInformation.PatientId, PatientInformationField.PhoneNumber),
+            UnprotectOptional(encryptedPatientInformation.StreetAddress, encryptedPatientInformation.PatientId, PatientInformationField.StreetAddress));
+    }
+
+    private EncryptedValue ProtectRequired(string value, string patientId, PatientInformationField field)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException($"Patient {field} is required.", nameof(value));
+        }
+
+        return Protect(value, patientId, field);
+    }
+
+    private EncryptedValue? ProtectOptional(string? value, string patientId, PatientInformationField field)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : Protect(value, patientId, field);
+    }
+
+    private EncryptedValue Protect(string value, string patientId, PatientInformationField field)
+    {
+        var purpose = BuildPurpose(patientId, field);
+        return dbEncryptionService.Encrypt(Encoding.UTF8.GetBytes(value), purpose);
+    }
+
+    private string UnprotectRequired(EncryptedValue encryptedValue, string patientId, PatientInformationField field)
+    {
+        ArgumentNullException.ThrowIfNull(encryptedValue);
+
+        var value = Unprotect(encryptedValue, patientId, field);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"Patient {field} decrypted to an empty value.");
+        }
+
+        return value;
+    }
+
+    private string? UnprotectOptional(EncryptedValue? encryptedValue, string patientId, PatientInformationField field)
+    {
+        return encryptedValue is null ? null : Unprotect(encryptedValue, patientId, field);
+    }
+
+    private string Unprotect(EncryptedValue encryptedValue, string patientId, PatientInformationField field)
+    {
+        var expectedPurpose = BuildPurpose(patientId, field);
+        if (!string.Equals(encryptedValue.Purpose, expectedPurpose, StringComparison.Ordinal))
+        {
+            throw new ArgumentException($"Encrypted patient {field} was protected with an unexpected purpose.", nameof(encryptedValue));
+        }
+
+        return Encoding.UTF8.GetString(dbEncryptionService.Decrypt(encryptedValue));
+    }
+
+    private static string BuildPurpose(string patientId, PatientInformationField field)
+    {
+        return $"{DataProtectionDbEncryptionService.DefaultPurpose}.PatientIdentifiableInformation.{patientId}.{field}";
+    }
+
+    private enum PatientInformationField
+    {
+        FirstName,
+        LastName,
+        DateOfBirth,
+        MedicalRecordNumber,
+        EmailAddress,
+        PhoneNumber,
+        StreetAddress,
+    }
+}

--- a/tests/ServiceStackApp.Tests/PatientIdentifiableInformationEncryptionServiceTests.cs
+++ b/tests/ServiceStackApp.Tests/PatientIdentifiableInformationEncryptionServiceTests.cs
@@ -1,0 +1,97 @@
+using System.Text;
+using DbEncryption;
+using Microsoft.AspNetCore.DataProtection;
+using NUnit.Framework;
+
+namespace ServiceStackApp.Tests;
+
+public sealed class PatientIdentifiableInformationEncryptionServiceTests
+{
+    [Test]
+    public void Encrypt_protects_patient_identifiable_information_fields()
+    {
+        var service = CreateService();
+        var patientInformation = CreatePatientInformation();
+
+        var encrypted = service.Encrypt(patientInformation);
+
+        Assert.That(encrypted.PatientId, Is.EqualTo(patientInformation.PatientId));
+        Assert.That(encrypted.FirstName.ProtectedData, Is.Not.EqualTo(Encoding.UTF8.GetBytes(patientInformation.FirstName)));
+        Assert.That(encrypted.LastName.ProtectedData, Is.Not.EqualTo(Encoding.UTF8.GetBytes(patientInformation.LastName)));
+        Assert.That(encrypted.DateOfBirth.ProtectedData, Is.Not.EqualTo(Encoding.UTF8.GetBytes("1984-02-29")));
+        Assert.That(encrypted.MedicalRecordNumber, Is.Not.Null);
+        Assert.That(encrypted.EmailAddress, Is.Not.Null);
+        Assert.That(encrypted.PhoneNumber, Is.Not.Null);
+        Assert.That(encrypted.StreetAddress, Is.Not.Null);
+    }
+
+    [Test]
+    public void Decrypt_restores_patient_identifiable_information()
+    {
+        var service = CreateService();
+        var patientInformation = CreatePatientInformation();
+
+        var encrypted = service.Encrypt(patientInformation);
+        var decrypted = service.Decrypt(encrypted);
+
+        Assert.That(decrypted, Is.EqualTo(patientInformation));
+    }
+
+    [Test]
+    public void Encrypt_uses_distinct_patient_field_purposes()
+    {
+        var service = CreateService();
+        var patientInformation = CreatePatientInformation();
+
+        var encrypted = service.Encrypt(patientInformation);
+
+        Assert.That(encrypted.FirstName.Purpose, Does.Contain($".{patientInformation.PatientId}.FirstName"));
+        Assert.That(encrypted.LastName.Purpose, Does.Contain($".{patientInformation.PatientId}.LastName"));
+        Assert.That(encrypted.DateOfBirth.Purpose, Does.Contain($".{patientInformation.PatientId}.DateOfBirth"));
+        Assert.That(encrypted.MedicalRecordNumber!.Purpose, Does.Contain($".{patientInformation.PatientId}.MedicalRecordNumber"));
+        Assert.That(encrypted.EmailAddress!.Purpose, Does.Contain($".{patientInformation.PatientId}.EmailAddress"));
+        Assert.That(encrypted.PhoneNumber!.Purpose, Does.Contain($".{patientInformation.PatientId}.PhoneNumber"));
+        Assert.That(encrypted.StreetAddress!.Purpose, Does.Contain($".{patientInformation.PatientId}.StreetAddress"));
+    }
+
+    [Test]
+    public void Encrypt_omits_optional_empty_patient_identifiable_information_fields()
+    {
+        var service = CreateService();
+        var patientInformation = new PatientIdentifiableInformation(
+            "patient-456",
+            "Grace",
+            "Hopper",
+            new DateOnly(1906, 12, 9));
+
+        var encrypted = service.Encrypt(patientInformation);
+        var decrypted = service.Decrypt(encrypted);
+
+        Assert.That(encrypted.MedicalRecordNumber, Is.Null);
+        Assert.That(encrypted.EmailAddress, Is.Null);
+        Assert.That(encrypted.PhoneNumber, Is.Null);
+        Assert.That(encrypted.StreetAddress, Is.Null);
+        Assert.That(decrypted, Is.EqualTo(patientInformation));
+    }
+
+    private static PatientIdentifiableInformationEncryptionService CreateService()
+    {
+        var dataProtectionProvider = new EphemeralDataProtectionProvider();
+        var dbEncryptionService = new DataProtectionDbEncryptionService(dataProtectionProvider);
+
+        return new PatientIdentifiableInformationEncryptionService(dbEncryptionService);
+    }
+
+    private static PatientIdentifiableInformation CreatePatientInformation()
+    {
+        return new PatientIdentifiableInformation(
+            "patient-123",
+            "Ada",
+            "Lovelace",
+            new DateOnly(1984, 2, 29),
+            "MRN-12345",
+            "ada@example.test",
+            "+1-555-0100",
+            "123 Example Street");
+    }
+}

--- a/tests/ServiceStackApp.Tests/ServiceStackApp.Tests.csproj
+++ b/tests/ServiceStackApp.Tests/ServiceStackApp.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="NUnit" Version="4.*" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DbEncryption\DbEncryption.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
### Motivation

- Provide a reusable library to protect patient identifiable information before persisting to a database using the Microsoft Data Protection API.
- Ensure each protected field carries its Data Protection purpose so values can be unprotected safely and purpose-verified on read.
- Integrate the new library into the solution and document usage in the repository README.

### Description

- Add a new project `src/DbEncryption` containing `IDbEncryptionService`, `DataProtectionDbEncryptionService`, `IPatientIdentifiableInformationEncryptionService`, and `PatientIdentifiableInformationEncryptionService` to encrypt/decrypt PII with per-field purposes.
- Introduce record types `PatientIdentifiableInformation`, `EncryptedPatientIdentifiableInformation`, and `EncryptedValue` for typed input and persistable protected values, with Base64 helper on `EncryptedValue`.
- Update solution file `ServiceStackApp.sln` to include the new project and add `tests/ServiceStackApp.Tests` project with NUnit tests that exercise encryption/decryption and per-field purpose logic.
- Update `README.md` to document the new DB encryption helpers and guidance about Data Protection key persistence and purpose storage.

### Testing

- Added NUnit unit tests in `tests/ServiceStackApp.Tests` validating that `PatientIdentifiableInformationEncryptionService` protects fields, restores original values on decrypt, uses distinct field-level purposes, and omits empty optional fields.
- The tests are implemented to run via `dotnet test tests/ServiceStackApp.Tests` but no automated test run was executed as part of this change.
- Test project references an ephemeral Data Protection provider for deterministic in-process testing and compiles against .NET 10.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30cb606acc8324bb471296afa6cb92)